### PR TITLE
Features: remove categories and untrain tokens

### DIFF
--- a/lib/nbayes.rb
+++ b/lib/nbayes.rb
@@ -147,6 +147,11 @@ module NBayes
       }
     end
 
+    def delete_category(category)
+      data.delete(category) if data.has_key?(category)
+      categories
+    end
+
   end
 
   class Base
@@ -179,6 +184,11 @@ module NBayes
       end  # each vocab word
       remove_list.keys.each {|token| @vocab.delete(token) }
       # print "total vocab size is now #{vocab.size}\n"
+    end
+
+    # Delete an entire category from the classification data
+    def delete_category(category)
+      data.delete_category(category)
     end
 
     def train(tokens, category)

--- a/lib/nbayes.rb
+++ b/lib/nbayes.rb
@@ -60,6 +60,10 @@ module NBayes
       data.keys
     end
 
+    def token_trained?(token, category)
+      data[category] ? data[category][:tokens].has_key?(token) : false
+    end
+
     def cat_data(category)
       unless data[category].is_a? Hash
         data[category] = new_category
@@ -87,6 +91,13 @@ module NBayes
       cat_data(category)[:examples] += 1
     end
 
+    # Decrement the number of training examples for this category.
+    # Delete the category if the examples counter is 0.
+    def decrement_examples(category)
+      cat_data(category)[:examples] -= 1
+      delete_category(category) if cat_data(category)[:examples] < 1
+    end
+
     def example_count(category)
       cat_data(category)[:examples]
     end
@@ -107,6 +118,16 @@ module NBayes
     def add_token_to_category(category, token)
       cat_data(category)[:tokens][token] += 1
       cat_data(category)[:total_tokens] += 1
+    end
+
+    # Decrement the token counter in a category
+    # If the counter is 0, delete the token.
+    # If the total number of tokens is 0, delete the category.
+    def remove_token_from_category(category, token)
+      cat_data(category)[:tokens][token] -= 1
+      delete_token_from_category(category, token) if cat_data(category)[:tokens][token] < 1
+      cat_data(category)[:total_tokens] -= 1
+      delete_category(category) if cat_data(category)[:total_tokens] < 1
     end
 
     # How many times does this token appear in this category?
@@ -197,6 +218,22 @@ module NBayes
       tokens.each do |token|
         vocab.seen_token(token)
         data.add_token_to_category(category, token)
+      end
+    end
+
+    # Be carefull with this function:
+    # * It decrement the number of examples for the category.
+    #   If the being-untrained category has no more examples, it is removed from the category list.
+    # * It untrain already trained tokens, non existing tokens are not considered.
+    def untrain(tokens, category)
+      tokens = tokens.uniq if binarized
+      data.decrement_examples(category)
+      
+      tokens.each do |token|
+        if data.token_trained?(token, category)
+          vocab.delete(token)
+          data.remove_token_from_category(category, token)
+        end
       end
     end
 

--- a/spec/nbayes_spec.rb
+++ b/spec/nbayes_spec.rb
@@ -174,4 +174,30 @@ describe "NBayes" do
     @nbayes.delete_category('classB').should == ["classA"]
     @nbayes.data.categories.should == ["classA"]
   end
+
+  it "should untrain a class" do
+    @nbayes.train( %w[a b c d e f g], 'classA' )
+    @nbayes.train( %w[a b c d e f g], 'classB' )
+    @nbayes.train( %w[a b c d e f g], 'classB' )
+    @nbayes.untrain( %w[a b c d e f g], 'classB' )
+    results = @nbayes.classify( %w[a b c] )
+    results['classA'].should == 0.5
+    results['classB'].should == 0.5
+  end
+
+  it "should remove the category when the only example is untrained" do
+    @nbayes.train( %w[a b c d e f g], 'classA' )
+    @nbayes.untrain( %w[a b c d e f g], 'classA' )
+    @nbayes.data.categories.should == []
+  end
+
+  it 'try untraining a non-existant category' do
+    @nbayes.train( %w[a b c d e f g], 'classA' )
+    @nbayes.train( %w[a b c d e f g], 'classB' )
+    @nbayes.untrain( %w[a b c d e f g], 'classC' )
+    @nbayes.data.categories.should == ['classA', 'classB']
+    results = @nbayes.classify( %w[a b c] )
+    results['classA'].should == 0.5
+    results['classB'].should == 0.5
+  end
 end

--- a/spec/nbayes_spec.rb
+++ b/spec/nbayes_spec.rb
@@ -159,4 +159,19 @@ describe "NBayes" do
     results = @nbayes.classify( ['b'] )
     results['classB'].should >= 0.5
   end
+
+  it "should delete a category" do
+    @nbayes.train( %w[a a a a], 'classA' )
+    @nbayes.train( %w[b b b b], 'classB' )
+    @nbayes.data.categories.should == ["classA", "classB"]
+    @nbayes.delete_category('classB').should == ["classA"]
+    @nbayes.data.categories.should == ["classA"]
+  end
+
+  it "should do nothing if asked to delete an inexistant category" do
+    @nbayes.train( %w[a a a a], 'classA' )
+    @nbayes.data.categories.should == ["classA"]
+    @nbayes.delete_category('classB').should == ["classA"]
+    @nbayes.data.categories.should == ["classA"]
+  end
 end


### PR DESCRIPTION
I'm on a project where I need the ability to untrain tokens from a category on demand.

These commits add the two features: **deleting a category from the classifier data** and **untraining already trained tokens**.

Notes concerning the untraining of tokens:
* It decrement the number of examples for the category.
  If the being-untrained category has no more examples, it is removed from the category list.
* It untrain already trained tokens, non existing tokens are not considered.